### PR TITLE
Add coroutine helper to create async functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yacol",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "",
   "main": "dist/",
   "repository": {

--- a/src/cor.js
+++ b/src/cor.js
@@ -236,6 +236,12 @@ export function run(runnable, ...args) {
   return runWithOptions({}, runnable, ...args)
 }
 
+export function coroutine(fn) {
+  return function(...args) {
+    return run(fn, ...args)
+  }
+}
+
 /* `parent` is used as a parent for the newly created coroutine. This creates other-than-default
  * coroutine hierarchy and should be used with care */
 export function runWithParent(parent, runnable, ...args) {

--- a/tests/coroutine.js
+++ b/tests/coroutine.js
@@ -1,0 +1,22 @@
+import {coroutine, run} from '../dist'
+import {assert} from 'chai'
+import {resetTimer, timeApprox, delay} from './utils'
+
+const inc = coroutine(function*(a, b) {
+  yield run(delay, 100)
+  return a + b
+})
+
+beforeEach(resetTimer)
+
+describe('coroutine', () => {
+  it('can define async function', (done) => {
+    coroutine(function*() {
+      const res = yield inc(1, 2)
+      yield run(delay, 100)
+      timeApprox(200)
+      assert.equal(res, 3)
+      done()
+    })()
+  })
+})


### PR DESCRIPTION
This is inspired by http://bluebirdjs.com/docs/api/promise.coroutine.html

It enables us to use babel-plugin-transform-async-to-module-method and use
async, await keywords with yacol.